### PR TITLE
[Example/DoNotMerge] Adding divide route 

### DIFF
--- a/server/src/routes/api.js
+++ b/server/src/routes/api.js
@@ -38,4 +38,15 @@ router.get("/add", async (req, res) => {
   });
 });
 
+router.get("/divide", async (req, res) => {
+  const a = parseFloat(req.query.a) || 0;
+  const b = parseFloat(req.query.b) || 0;
+
+  const result = a * b;
+
+  return res.json({
+    result
+  });
+});
+
 export default router;

--- a/server/tests/sample.test.js
+++ b/server/tests/sample.test.js
@@ -32,4 +32,24 @@ describe("Server", () => {
         done();
       });
   });
+
+  it("Divides properly", done => {
+    request(app)
+      .get("/api/divide?a=6&b=3")
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.result).toEqual(2);
+        done();
+      });
+  });
+
+  it("Divides by zero properly", done => {
+    request(app)
+      .get("/api/divide?a=6&b=0")
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.result).toEqual(null);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Example `divide` route to illustrate good PR practices