### PR TITLE
[enhancement] added custom Head component for title tags, Google Analytics, favicon, and more

### DIFF
--- a/components/Head.tsx
+++ b/components/Head.tsx
@@ -1,0 +1,37 @@
+import { default as NextHead } from "next/head";
+
+type HeadProps = {
+  title: string;
+};
+
+const Head = ({ title }: HeadProps) => {
+  return (
+    <NextHead>
+      <title>{title}</title>
+      <meta
+        name="viewport"
+        content="initial-scale=1.0, width=device-width"
+        key="viewport"
+      />
+
+      <script
+        async
+        src="https://www.googletagmanager.com/gtag/js?id=UA-127488741-2"
+      ></script>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-127488741-2');
+      `
+        }}
+      />
+
+      <link rel="icon" type="image/png" href="/favicon.png" />
+    </NextHead>
+  );
+};
+
+export default Head;

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { handleLoginRedirect, getProfile } from "../lib/authenticate";
 
+import Head from "../components/Head";
 import FormStepper from "../components/FormStepper";
 import StatusStep from "../components/applicationSteps/StatusStep";
 import ApplicationStep from "../components/applicationSteps/ApplicationStep";
@@ -36,6 +37,7 @@ const formSteps: FormStep[] = [
 const Dashboard = ({ profile }) => {
   return (
     <>
+      <Head title="HackSC Odyssey - Dashboard" />
       <Navbar loggedIn />
       <FormStepper serverStep={0} steps={formSteps} profile={profile} />
       <Footer />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { getUser, handleDashboardRedirect } from "../lib/authenticate";
 
+import Head from "../components/Head";
 import Navbar from "../components/Navbar";
 import Hero from "../components/Hero";
 import Footer from "../components/Footer";
@@ -9,6 +10,7 @@ import { Container } from "../styles";
 const Home = () => {
   return (
     <>
+      <Head title="HackSC Odyssey - Apply to HackSC 2020" />
       <Navbar />
       <Container>
         <Hero />


### PR DESCRIPTION
<img width="336" alt="Screen Shot 2019-11-01 at 11 47 55 AM" src="https://user-images.githubusercontent.com/4969041/68048269-738a0180-fc9d-11e9-9e95-0f13fc54e4b7.png">

Previously, our pages had no `<title>` or favicon. This adds some meta data, including the responsive width tag, plus Google Analytics