### PR TITLE
[enhancement] application tabs affect browser history, can be linked, and other usability things

### DIFF
--- a/components/FormStepper.tsx
+++ b/components/FormStepper.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { Container, Panel } from "../styles";
 import styled, { DefaultTheme } from "styled-components";
 
+import Router from "next/router";
+
 type Props = {
   serverStep: number;
   steps: FormStep[];
@@ -11,9 +13,7 @@ type Props = {
 const FormStepper: React.FunctionComponent<Props> = props => {
   const { steps, serverStep, profile } = props;
 
-  const [currentStep, setCurrentStep] = React.useState(serverStep);
-
-  const CurrentStep = steps[currentStep].component;
+  const CurrentStep = steps[serverStep].component;
 
   return (
     <Wrapper>
@@ -22,8 +22,8 @@ const FormStepper: React.FunctionComponent<Props> = props => {
           {steps.map((step, i) => (
             <FormHeaderStep
               key={i}
-              onClick={() => setCurrentStep(i)}
-              active={i == currentStep}
+              onClick={() => Router.push(`/dashboard/${step.slug}`)}
+              active={i == serverStep}
             >
               {step.title}
             </FormHeaderStep>

--- a/components/applicationSteps/ApplicationStep.tsx
+++ b/components/applicationSteps/ApplicationStep.tsx
@@ -55,9 +55,13 @@ const ApplicationStep: React.FunctionComponent<Props> = props => {
           <FormGroup>
             <label>
               HackSC has four verticals centered around social justice: civil
-              liberties, sustainability, equity, and mental health. If you were
-              admitted to HackSC 2020, which vertical would you tackle and what
-              would you build? (1000 characters)
+              liberties, sustainability, equity, and mental health. Read more
+              about them at{" "}
+              <a href="https://hacksc.com" target="_blank">
+                hacksc.com
+              </a>
+              . If you were admitted to HackSC 2020, which vertical would you
+              tackle and what would you build? (1000 characters)
             </label>
 
             <textarea
@@ -156,31 +160,38 @@ const ApplicationStep: React.FunctionComponent<Props> = props => {
         </FormSection>
 
         <FormSection>
-          <Flex justify="space-between">
-            <Column flexBasis={49}>
-              <Flex>
-                <Button
-                  outline
-                  onClick={e => saveApplication(e, formRef, setSaved, setError)}
-                  disabled={submitted}
-                >
-                  Save
-                </Button>
+          {!submitted && (
+            <>
+              <Flex justify="space-between">
+                <Column flexBasis={49}>
+                  <Flex>
+                    <Button
+                      outline
+                      onClick={e =>
+                        saveApplication(e, formRef, setSaved, setError)
+                      }
+                      disabled={submitted}
+                    >
+                      Save for later
+                    </Button>
+                  </Flex>
+                </Column>
+                <Column flexBasis={49}>
+                  <Flex>
+                    <Button type="submit" disabled={submitted}>
+                      Submit
+                    </Button>
+                  </Flex>
+                </Column>
               </Flex>
-            </Column>
-            <Column flexBasis={49}>
-              <Flex>
-                <Button type="submit" disabled={submitted}>
-                  Submit
-                </Button>
-              </Flex>
-            </Column>
-          </Flex>
 
-          <SubmitWarningMessage>
-            You can only submit your application once! Be sure everything is
-            good to go before you submit.
-          </SubmitWarningMessage>
+              <SubmitWarningMessage>
+                You can only submit your application once! Be sure everything is
+                good to go before you submit.
+              </SubmitWarningMessage>
+            </>
+          )}
+
           {saved && (
             <SavedMessage>Application saved successfully.</SavedMessage>
           )}
@@ -219,6 +230,7 @@ const SubmitWarningMessage = styled.p`
   text-align: center;
   font-weight: 600;
   padding: 32px 0 0;
+  margin-bottom: 16px;
   color: ${({ theme }) => theme.colors.black};
 `;
 
@@ -237,7 +249,6 @@ const SubmittedMessage = styled.p`
   text-align: center;
   font-weight: 600;
   padding: 32px 0 0;
-  margin-top: 16px;
   padding: 16px;
   border: 2px solid ${({ theme }) => theme.colors.blue};
   color: ${({ theme }) => theme.colors.gray50};

--- a/components/applicationSteps/ProfileStep.tsx
+++ b/components/applicationSteps/ProfileStep.tsx
@@ -477,33 +477,38 @@ const ProfileStep: React.FunctionComponent<Props> = props => {
         </FormSection>
 
         <FormSection>
-          <Flex justify="space-between">
-            <Column flexBasis={49}>
-              <Flex>
-                <Button
-                  outline
-                  onClick={e => {
-                    saveProfile(e, formData, setSaved, setError);
-                  }}
-                  disabled={submitted}
-                >
-                  Save
-                </Button>
+          {!submitted && (
+            <>
+              <Flex justify="space-between">
+                <Column flexBasis={49}>
+                  <Flex>
+                    <Button
+                      outline
+                      onClick={e => {
+                        saveProfile(e, formData, setSaved, setError);
+                      }}
+                      disabled={submitted}
+                    >
+                      Save for later
+                    </Button>
+                  </Flex>
+                </Column>
+                <Column flexBasis={49}>
+                  <Flex>
+                    <Button type="submit" disabled={submitted}>
+                      Submit
+                    </Button>
+                  </Flex>
+                </Column>
               </Flex>
-            </Column>
-            <Column flexBasis={49}>
-              <Flex>
-                <Button type="submit" disabled={submitted}>
-                  Submit
-                </Button>
-              </Flex>
-            </Column>
-          </Flex>
 
-          <SubmitWarningMessage>
-            You can only submit your profile once! Be sure everything is good to
-            go before you submit.
-          </SubmitWarningMessage>
+              <SubmitWarningMessage>
+                You can only submit your profile once! Be sure everything is
+                good to go before you submit.
+              </SubmitWarningMessage>
+            </>
+          )}
+
           {saved && <SavedMessage>Profile saved successfully.</SavedMessage>}
           {submitted && (
             <SubmittedMessage>
@@ -565,6 +570,7 @@ const SubmitWarningMessage = styled.p`
   text-align: center;
   font-weight: 600;
   padding: 32px 0 0;
+  margin-bottom: 16px;
   color: ${({ theme }) => theme.colors.black};
 `;
 

--- a/components/applicationSteps/ResultStep.tsx
+++ b/components/applicationSteps/ResultStep.tsx
@@ -1,11 +1,52 @@
 import * as React from "react";
 
+import styled from "styled-components";
+
+import { Flex } from "../../styles";
+
 type Props = {
   user: any;
 };
 
 const ResultStep: React.FunctionComponent<Props> = props => {
-  return <div>Results</div>;
+  return (
+    <Flex direction="column">
+      <FormSection>
+        <h1>HackSC Application Results</h1>
+
+        <p>
+          Thank you for filling out an application for HackSC 2020! Be on the
+          look out for updates on when applications come out.
+        </p>
+
+        <p>
+          In the meantime, follow HackSC on social media. Follow us on{" "}
+          <a href="https://twitter.com/hackscofficial" target="_blank">
+            Twitter
+          </a>
+          ,{" "}
+          <a href="https://instagram.com/hackscofficial" target="_blank">
+            Instagram
+          </a>
+          , and{" "}
+          <a href="https://www.facebook.com/hackscofficial" target="_blank">
+            Facebook
+          </a>
+        </p>
+      </FormSection>
+    </Flex>
+  );
 };
+
+const FormSection = styled.div`
+  border-radius: 4px;
+  background-color: ${({ theme }) => theme.colors.white};
+  padding: 48px;
+  margin-bottom: 64px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
 
 export default ResultStep;

--- a/components/applicationSteps/StatusStep.tsx
+++ b/components/applicationSteps/StatusStep.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 
 import styled from "styled-components";
 
+import Router from "next/router";
+
 import { Flex, Column, Button } from "../../styles";
 
 import Check from "../../assets/check.svg";
@@ -25,6 +27,10 @@ const getStage = (status: string): number => {
     return 2;
   }
   return 3;
+};
+
+const navigateTo = (step: string): void => {
+  Router.push(`/dashboard/${step}`);
 };
 
 const StatusStep: React.FunctionComponent<Props> = props => {
@@ -55,7 +61,9 @@ const StatusStep: React.FunctionComponent<Props> = props => {
               <p>Set up your hacker profile so we can learn more about you.</p>
 
               {getStage(status) === 1 && (
-                <StepButton>Set Up Profile</StepButton>
+                <StepButton onClick={() => navigateTo("profile")}>
+                  Set Up Profile
+                </StepButton>
               )}
             </Step>
             <Step>
@@ -66,13 +74,19 @@ const StatusStep: React.FunctionComponent<Props> = props => {
               </p>
 
               {getStage(status) === 2 && (
-                <StepButton>Fill out application</StepButton>
+                <StepButton onClick={() => navigateTo("application")}>
+                  Fill out application
+                </StepButton>
               )}
             </Step>
             <Step>
               <h3>3. View Results</h3>
               <p>Come back on December 1st, 2019 to see your results.</p>
-              {getStage(status) === 3 && <StepButton>View Results</StepButton>}
+              {getStage(status) === 3 && (
+                <StepButton onClick={() => navigateTo("results")}>
+                  View Results
+                </StepButton>
+              )}
             </Step>
           </Steps>
         </Column>

--- a/odyssey.d.ts
+++ b/odyssey.d.ts
@@ -8,6 +8,7 @@ declare type FormStepProps = {
 
 declare type FormStep = {
   title: string;
+  slug: string;
   component: React.FunctionComponent<FormStepProps>;
 };
 

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -17,27 +17,31 @@ import Footer from "../components/Footer";
 const formSteps: FormStep[] = [
   {
     title: "Status",
+    slug: "status",
     component: StatusStep
   },
   {
     title: "Profile",
+    slug: "profile",
     component: ProfileStep
   },
   {
     title: "Application",
+    slug: "application",
     component: ApplicationStep
   },
   {
     title: "Results",
+    slug: "results",
     component: ResultStep
   }
 ];
 
-const Dashboard = ({ profile }) => {
+const Dashboard = ({ profile, step }) => {
   return (
     <>
       <Navbar loggedIn />
-      <FormStepper serverStep={0} steps={formSteps} profile={profile} />
+      <FormStepper serverStep={step} steps={formSteps} profile={profile} />
       <Footer />
     </>
   );
@@ -51,8 +55,23 @@ Dashboard.getInitialProps = async ({ req }) => {
     handleLoginRedirect(req);
   }
 
+  // Convert step param into an int
+  const step =
+    req && req.params && req.params.step
+      ? req.params.step === "status"
+        ? 0
+        : req.params.step === "profile"
+        ? 1
+        : req.params.step === "application"
+        ? 2
+        : req.params.step === "results"
+        ? 3
+        : 0
+      : 0;
+
   return {
-    profile
+    profile,
+    step: step || 0
   };
 };
 

--- a/server.js
+++ b/server.js
@@ -69,6 +69,10 @@ app.prepare().then(() => {
   server.use("/auth", authRouter);
   server.use("/api/profile", profileRouter);
   server.use("/api/admin", adminRouter);
+
+  server.get("/dashboard/:step", (req, res) =>
+    app.render(req, res, "/dashboard")
+  );
   server.get("*", handle);
 
   const port_num = process.env.PORT || 3000;


### PR DESCRIPTION
Previously, clicking a tab didn't affect the browser history. This would break the back button which users will expect to work. This makes it so tabs can be linked to via a url (`/dashboard/application`) and so that they add on to the browser history, allowing for the back button to be used.

Also made some changes to rendering logic for save + submit buttons and did some small usability stuff. Also set up temporary `results` tab.

TODO: Prevent users from moving onto application or results tab until they've completed the tab prior