### PR TITLE
[bugfix] removing port from production deploy 

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -44,7 +44,12 @@ router.get("/logout", (req, res) => {
   req.logout();
   var returnTo = req.protocol + "://" + req.hostname;
   const port = req.connection.localPort;
-  if (port !== undefined && port !== 80 && port !== 443) {
+  if (
+    port !== undefined &&
+    req.hostname == "localhost" &&
+    port !== 80 &&
+    port !== 443
+  ) {
     returnTo += ":" + port;
   }
   var logoutURL = new url.URL(


### PR DESCRIPTION
Fixes #59, so now logging out works

## Quick explanation: 

Evidently heroku doesn't let you `GET` the application with the port specified, so this change basically removes the port part for non-local deployments, which then fixes the issue. 