### PR TITLE
[fix] status page does additional checks in case status doesn't update properly

### DIFF
--- a/components/steps/Status.tsx
+++ b/components/steps/Status.tsx
@@ -13,20 +13,26 @@ type Props = {
   profile: Profile;
 };
 
-const getStatusLabel = (status: string) => {
+const getStatusLabel = (profile: Profile): string => {
+  const { status, submittedAt } = profile;
   if (!status || status === "unverified") {
     return "Unverified";
   }
   if (status === "checkedIn") return "Checked In";
+  if (status === "verified" && submittedAt !== null) {
+    return "Submitted";
+  }
 
   return status[0].toUpperCase() + status.substring(1, status.length);
 };
 
 const getStage = (profile: Profile): number => {
-  if (profile.status === "unverified") {
+  const { status, submittedAt } = profile;
+
+  if (status === "unverified") {
     return 1;
-  } else if (profile.status === "verified") {
-    if (profile.submittedAt !== null) {
+  } else if (status === "verified") {
+    if (submittedAt !== null) {
       Sentry.captureMessage(
         "Status = verified but should actually be submitted!!!"
       );
@@ -44,9 +50,8 @@ const navigateTo = (step: string): void => {
 
 const StatusStep: React.FunctionComponent<Props> = props => {
   const { profile } = props;
-  const { status } = profile;
 
-  const statusLabel = getStatusLabel(status);
+  const statusLabel = getStatusLabel(profile);
 
   return (
     <Flex direction="column">

--- a/components/steps/Status.tsx
+++ b/components/steps/Status.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
-
 import styled from "styled-components";
-
 import Router from "next/router";
+import * as Sentry from "@sentry/browser";
 
 import getProfileStage from "../../lib/getProfileStage";
 
@@ -26,10 +25,16 @@ const getStatusLabel = (status: string) => {
 const getStage = (profile: Profile): number => {
   if (profile.status === "unverified") {
     return 1;
-  } else if (profile.status === "verified" && !profile.submittedAt) {
+  } else if (profile.status === "verified") {
+    if (profile.submittedAt !== null) {
+      Sentry.captureMessage(
+        "Status = verified but should actually be submitted!!!"
+      );
+      return 3;
+    }
+
     return 2;
   }
-
   return 3;
 };
 

--- a/components/steps/Status.tsx
+++ b/components/steps/Status.tsx
@@ -23,12 +23,13 @@ const getStatusLabel = (status: string) => {
   return status[0].toUpperCase() + status.substring(1, status.length);
 };
 
-const getStage = (status: string): number => {
-  if (status === "unverified") {
+const getStage = (profile: Profile): number => {
+  if (profile.status === "unverified") {
     return 1;
-  } else if (status === "verified") {
+  } else if (profile.status === "verified" && !profile.submittedAt) {
     return 2;
   }
+
   return 3;
 };
 
@@ -59,21 +60,21 @@ const StatusStep: React.FunctionComponent<Props> = props => {
         <Column flexBasis={63}>
           <h2>Next Steps</h2>
           <Steps>
-            <Step disabled={getStage(status) > 1}>
+            <Step disabled={getStage(profile) > 1}>
               <h3>1. Verify your e-mail</h3>
               <p>
                 Make sure to check your e-mail and verify your account. If you
                 run into issues, log-out and log back in.
               </p>
             </Step>
-            <Step disabled={getStage(status) > 2}>
+            <Step disabled={getStage(profile) > 2}>
               <h3>2. Fill out an application</h3>
               <p>
                 Answer a few questions to show why you want to be at HackSC
                 2020!
               </p>
 
-              {getStage(status) === 2 && (
+              {getStage(profile) === 2 && (
                 <StepButton onClick={() => navigateTo("application")}>
                   Fill out application
                 </StepButton>
@@ -82,7 +83,7 @@ const StatusStep: React.FunctionComponent<Props> = props => {
             <Step>
               <h3>3. View Results</h3>
               <p>Come back soon and see your results.</p>
-              {getStage(status) === 3 && (
+              {getStage(profile) === 3 && (
                 <StepButton onClick={() => navigateTo("results")}>
                   View Results
                 </StepButton>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@auth0/auth0-spa-js": "^1.2.4",
     "@babel/register": "^7.6.2",
+    "@sentry/browser": "^5.7.1",
     "@sentry/node": "^5.7.1",
     "@types/styled-components": "^4.1.19",
     "auth0-js": "^9.11.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import App from "next/app";
 import { ThemeProvider } from "styled-components";
 import { hotjar } from "react-hotjar";
+import * as Sentry from "@sentry/browser";
 
 import { Theme, GlobalStyles } from "../styles";
 
@@ -21,6 +22,10 @@ class OdysseyApp extends App {
     if (process.env.NODE_ENV === "production") {
       hotjar.initialize("1547187");
     }
+
+    Sentry.init({
+      dsn: "https://1a18ac7b9aa94cb5b2a8c9fc2f7e4fc8@sentry.io/1801129"
+    });
   }
 
   render() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,9 +23,11 @@ class OdysseyApp extends App {
       hotjar.initialize("1547187");
     }
 
-    Sentry.init({
-      dsn: "https://1a18ac7b9aa94cb5b2a8c9fc2f7e4fc8@sentry.io/1801129"
-    });
+    if (typeof window !== "undefined") {
+      Sentry.init({
+        dsn: "https://1a18ac7b9aa94cb5b2a8c9fc2f7e4fc8@sentry.io/1801129"
+      });
+    }
   }
 
   render() {

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import * as Sentry from "@sentry/browser";
 
 import { handleLoginRedirect, getProfile } from "../lib/authenticate";
 
@@ -31,6 +32,12 @@ Dashboard.getInitialProps = async ({ req }) => {
   // Null profile means user is not logged in
   if (!profile) {
     handleLoginRedirect(req);
+  }
+
+  if (typeof window !== "undefined") {
+    Sentry.configureScope(function(scope) {
+      scope.setExtra("profile", profile);
+    });
   }
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,6 +1097,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@sentry/browser@^5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.7.1.tgz#1f8435e2a325d7a09f830065ebce40a2b3c708a4"
+  integrity sha512-K0x1XhsHS8PPdtlVOLrKZyYvi5Vexs9WApdd214bO6KaGF296gJvH1mG8XOY0+7aA5i2A7T3ttcaJNDYS49lzw==
+  dependencies:
+    "@sentry/core" "5.7.1"
+    "@sentry/types" "5.7.1"
+    "@sentry/utils" "5.7.1"
+    tslib "^1.9.3"
+
 "@sentry/core@5.7.1":
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.7.1.tgz#3eb2b7662cac68245931ee939ec809bf7a639d0e"


### PR DESCRIPTION
Right now, it doesn't seem like #63 is happening in staging anymore.. but just in case, this PR changes the status page logic so that it does additional checks to ensure a user sees the right "next steps"

TODO:
* Add Sentry client-side logging 