### PR TITLE
removing login reroutes

### DIFF
--- a/api/login.js
+++ b/api/login.js
@@ -10,7 +10,7 @@ var secured = function(req, res, next) {
     return next();
   }
   req.session.returnTo = req.originalUrl;
-  res.redirect("/login");
+  res.redirect("/");
 };
 
 router.get(
@@ -29,7 +29,7 @@ router.get("/callback", function(req, res, next) {
       return next(err);
     }
     if (!user) {
-      return res.redirect("/login");
+      return res.redirect("/");
     }
     req.logIn(user, function(err) {
       if (err) {

--- a/lib/authenticate.tsx
+++ b/lib/authenticate.tsx
@@ -44,7 +44,7 @@ export function secured(req, res, next) {
     return next();
   }
   req.session.returnTo = req.originalUrl;
-  res.redirect("/login");
+  res.redirect("/");
 }
 
 function redirectToPath(req, path: string) {


### PR DESCRIPTION
Moves `/login`, to `/`, so that way at least our app doesn't `404`