### PR TITLE
[enhancement][server] enable cookie sessions for persistent sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "body-parser": "^1.19.0",
     "busboy": "^0.3.1",
     "cookie": "^0.4.0",
+    "cookie-session": "^1.3.3",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-fileupload": "^1.1.6-alpha.6",

--- a/server.js
+++ b/server.js
@@ -1,10 +1,10 @@
 const express = require("express");
 const http = require("http");
 const next = require("next");
-const session = require("express-session");
 const dotenv = require("dotenv");
 const passport = require("passport");
 const Auth0Strategy = require("passport-auth0");
+const cookieSession = require("cookie-session");
 
 const bodyParser = require("body-parser");
 
@@ -45,10 +45,13 @@ const strategy = new Auth0Strategy(
 );
 
 const sessionConfig = {
-  secret: process.env.COOKIE_SECRET || "We haven't secured the cookies chief",
-  cookie: {},
-  resave: false,
-  saveUninitialized: true
+  name: "session",
+  keys: [process.env.COOKIE_SECRET || "We haven't secured the cookies chief"],
+  maxAge: 24 * 60 * 60 * 1000,
+  cookie: {
+    secure: true,
+    httpOnly: true
+  }
 };
 
 passport.use(strategy);
@@ -63,7 +66,7 @@ app.prepare().then(() => {
   const server = express();
 
   // Authentication config
-  server.use(session(sessionConfig));
+  server.use(cookieSession(sessionConfig));
   server.use(passport.initialize());
   server.use(passport.session());
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,6 +2685,15 @@ convert-source-map@1.6.0, convert-source-map@^1.1.0, convert-source-map@^1.4.0, 
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie-session@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/cookie-session/-/cookie-session-1.3.3.tgz#54fa63881bf87c4961863f7c059670be7517fdae"
+  integrity sha512-GrMdrU1YTQWtmVTo0Rj3peeZRMc2xJrBslFYtZcYTo+hrSLmrcf69OrRkDi84xTfylgCy2wgpRHyY4le6lE5+A==
+  dependencies:
+    cookies "0.7.3"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -2704,6 +2713,14 @@ cookiejar@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
+
+cookies@0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.3.tgz#7912ce21fbf2e8c2da70cf1c3f351aecf59dadfa"
+  integrity sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==
+  dependencies:
+    depd "~1.1.2"
+    keygrip "~1.0.3"
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -5307,6 +5324,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+keygrip@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.3.tgz#399d709f0aed2bab0a059e0cdd3a5023a053e1dc"
+  integrity sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"


### PR DESCRIPTION
This PR enables cookies for sessions. This stores session data in cookies which is stored in the client. Previously, session data was stored on the server in-memory.

This meant that when the server re-booted, session data was lost and users had to log back in. This hurts us for continuous deployment because it means every time we deploy, users will have to log back in. Not ideal if we're pushing out updates constantly 

Reading:

https://expressjs.com/en/advanced/best-practice-security.html

https://github.com/expressjs/cookie-session

https://stackoverflow.com/questions/23566555/whats-difference-with-express-session-and-cookie-session

#106 