### PR TITLE
[server][app review] Adds `GET` route for all profiles that can currently be reviewed by a person

### DIFF
--- a/api/admin.js
+++ b/api/admin.js
@@ -75,6 +75,34 @@ router.get("/reviews", async (req, res) => {
   }
 });
 
+router.get("/eligibleProfiles", async (req, res) => {
+  try {
+    const allProfiles = await models.HackerProfile.findAll({
+      where: {
+        submittedAt: {
+          [sequelize.Op.not]: null
+        }
+      },
+      include: [
+        {
+          model: models.HackerReview
+        }
+      ]
+    });
+    filteredProfiles = allProfiles.filter(profile => {
+      const reviewsByCurrUser = profile.HackerReviews.filter(review => {
+        return review.dataValues.createdBy === req.user.id;
+      });
+      return reviewsByCurrUser.length === 0 && profile.HackerReviews.length < 3;
+    });
+    return res.json({
+      eligibleReviews: filteredProfiles
+    });
+  } catch (e) {
+    return res.status(500).json({ error: e.message });
+  }
+});
+
 router.get("/review", async (req, res) => {
   try {
     const profilesWCount = await models.HackerProfile.findAll({


### PR DESCRIPTION
## What 
* Adds endpoint for getting all eligible Reviews 


## Why 

This fixes the issue of having one person submit an individual review, and is part of a larger rework to fix how exactly the backend infra will look to support app review. Instead of having a single endpoint that manages everything, we can pull all eligible `hackerProfiles`, and then choose from there to `POST` to create a new hacker Profile (endpoint coming soon), to submit a new review. This way we separate the responsibility across multiple endpoints and provides the frontend with more control as to how to create and manage reviews, without having to deal with the filtering business logic. 