### PR TITLE
[fix] add review history route to show reviews logged in user has made

### DIFF
--- a/api/admin.js
+++ b/api/admin.js
@@ -75,19 +75,6 @@ router.put("/review/:id", async (req, res) => {
   }
 });
 
-router.get("/reviews", async (req, res) => {
-  try {
-    const allReviews = await models.HackerReview.findAll({
-      where: {
-        createdBy: req.user.id
-      }
-    });
-    return res.json({ reviews: allReviews });
-  } catch (e) {
-    return res.status(500).json({ error: e.message });
-  }
-});
-
 router.get("/eligibleProfiles", async (req, res) => {
   try {
     const allProfiles = await models.HackerProfile.findAll({

--- a/api/admin.js
+++ b/api/admin.js
@@ -29,6 +29,19 @@ router.get("/reviews", async (req, res) => {
   }
 });
 
+router.get("/reviewHistory", async (req, res) => {
+  try {
+    const reviews = await models.HackerReview.findAll({
+      where: {
+        createdBy: req.user.id
+      }
+    });
+    return res.json({ reviews: reviews });
+  } catch (e) {
+    return res.status(500).json({ err: e });
+  }
+});
+
 router.put("/review/:id", async (req, res) => {
   const requestId = req.params.id;
   const allowedFields = new Set([

--- a/lib/admin.tsx
+++ b/lib/admin.tsx
@@ -1,7 +1,7 @@
-export async function getReviews(req) {
+export async function getReviewHistory(req) {
   const fetchUrl = process.env.URL_BASE
-    ? process.env.URL_BASE + "api/admin/reviews"
-    : "api/admin/reviews";
+    ? process.env.URL_BASE + "api/admin/reviewHistory"
+    : "api/admin/reviewHistory";
 
   const response = await fetch(
     fetchUrl,

--- a/pages/appReview.tsx
+++ b/pages/appReview.tsx
@@ -6,14 +6,14 @@ import { handleLoginRedirect, getProfile } from "../lib/authenticate";
 import {
   getHackerProfileForReview,
   submitReview,
-  getReviews
+  getReviewHistory
 } from "../lib/admin";
 import Head from "../components/Head";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import { Button, Container, Background, Flex, Column } from "../styles";
 
-const AppReview = ({ hackerProfile, reviews }) => {
+const AppReview = ({ hackerProfile, reviewHistory }) => {
   const [s1, setS1] = useState(null);
   const [s2, setS2] = useState(null);
   const [s3, setS3] = useState(null);
@@ -137,7 +137,8 @@ const AppReview = ({ hackerProfile, reviews }) => {
             <br />
 
             <p>
-              You have reviewed <b>{reviews ? reviews.length : 0}/200</b>{" "}
+              You have reviewed{" "}
+              <b>{reviewHistory ? reviewHistory.length : 0}/200</b>{" "}
               applications.
             </p>
           </InfoPanel>
@@ -249,10 +250,10 @@ AppReview.getInitialProps = async ctx => {
     handleLoginRedirect(req);
   }
   const profileReview = await getHackerProfileForReview(req);
-  const reviews = await getReviews(req);
+  const reviewHistory = await getReviewHistory(req);
   return {
     hackerProfile: profileReview,
-    reviews
+    reviewHistory
   };
 };
 


### PR DESCRIPTION
* adds an `/api/admin/reviewHistory` route that shows the review history of the logged-in user 
* app review page uses this to show how many user has reviewed