### PR TITLE
[enhancement] let users un-decline

### DIFF
--- a/api/hackerProfile.js
+++ b/api/hackerProfile.js
@@ -320,4 +320,24 @@ router.post("/decline", async (req, res) => {
   });
 });
 
+router.post("/undecline", async (req, res) => {
+  await models.HackerProfile.update(
+    {
+      status: "accepted",
+      declinedAt: null
+    },
+    {
+      where: {
+        userId: req.user.id,
+        status: "declined"
+      }
+    }
+  );
+
+  return res.json({
+    message:
+      "Successfully processed request to un-decline HackSC 2020 acceptance"
+  });
+});
+
 module.exports = router;

--- a/components/results/Declined.tsx
+++ b/components/results/Declined.tsx
@@ -1,23 +1,43 @@
 import React from "react";
 import styled from "styled-components";
+import Router from "next/router";
 
 import Blob from "../Blob";
-import { Flex } from "../../styles";
+import { Flex, Button } from "../../styles";
 
 type Props = {
   profile: Profile;
 };
 
 const Declined: React.FunctionComponent<Props> = props => {
+  const handleUndecline = async () => {
+    await fetch("/api/profile/undecline", {
+      method: "POST"
+    });
+
+    await Router.push("/dashboard");
+    window.scrollTo(0, 0);
+  };
+
   return (
     <Flex direction="column">
       <FormSection>
         <h1>You have declined your spot for HackSC 2020</h1>
 
+        <Flex align="center">
+          <p>
+            We're sad we won't be seeing you at HackSC 2020! If you decide to
+            change your mind, click the following to un-decline.
+          </p>
+
+          <UndeclineButton onClick={handleUndecline}>Undecline</UndeclineButton>
+        </Flex>
+
+        <LineBreak />
+
         <p>
-          We're sad we won't be seeing you at HackSC 2020! If you decide to
-          change your mind, please let us know at{" "}
-          <a href="mailto:hackers@hacksc.com">hackers@hacksc.com</a>
+          If you have any additional comments or questions, please let us know
+          at <a href="mailto:hackers@hacksc.com">hackers@hacksc.com</a>
         </p>
 
         <br />
@@ -63,6 +83,20 @@ const FormSection = styled.div`
   &:last-child {
     margin-bottom: 0;
   }
+`;
+
+const UndeclineButton = styled(Button)`
+  margin-left: 8px;
+`;
+
+const LineBreak = styled.hr`
+  color: ${({ theme }) => theme.colors.gray25};
+  background-color: ${({ theme }) => theme.colors.gray25};
+  border: 0;
+  height: 1px;
+  content: "";
+  display: block;
+  margin: 24px 0;
 `;
 
 export default Declined;

--- a/components/steps/Status.tsx
+++ b/components/steps/Status.tsx
@@ -95,8 +95,10 @@ const StatusStep: React.FunctionComponent<Props> = props => {
 
         {profile && profile.status === "declined" && (
           <StatusMessage>
-            We're sad to hear that you will not be attending HackSC 2020. If any
-            plans change, please let us know at{" "}
+            We're sad to hear that you will not be attending HackSC 2020.{" "}
+            <b>If you would like to un-decline</b>, please do so on{" "}
+            <a href="/results">the results page.</a> If you have any additional
+            questions or comments, please let us know at{" "}
             <a href="mailto:hackers@hacksc.com">hackers@hacksc.com</a>
           </StatusMessage>
         )}


### PR DESCRIPTION
<img width="917" alt="Screen Shot 2020-01-01 at 6 41 14 PM" src="https://user-images.githubusercontent.com/4969041/71647524-52a65280-2cc6-11ea-809a-74541553838b.png">
<img width="1003" alt="Screen Shot 2020-01-01 at 6 41 07 PM" src="https://user-images.githubusercontent.com/4969041/71647525-533ee900-2cc6-11ea-8799-ca56c6848dab.png">

If a user has the status of `declined`, they'll see these options on their status and results page. If they click the 'Undecline' button, it will set their status to `accepted` and will redirect them to the dashboard
