### PR TITLE
[database][battlepass] Adds multiplier element to the contrib, as an entry point for API rush

### DIFF
--- a/api/database/migrations/20200124192357-augment-contrib-with-multiplier.js
+++ b/api/database/migrations/20200124192357-augment-contrib-with-multiplier.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn("Contributions", "multiplier", {
+      type: Sequelize.INTEGER
+    });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn("Contributions", "multiplier");
+  }
+};

--- a/api/models/contribution.js
+++ b/api/models/contribution.js
@@ -3,6 +3,7 @@ module.exports = (sequelize, DataTypes) => {
     "Contribution",
     {
       personId: DataTypes.STRING(100),
+      multiplier: DataTypes.INTEGER,
       taskId: DataTypes.INTEGER
     },
     { tableName: "Contributions" }


### PR DESCRIPTION
## Quick explanation of how I'm envisioning building out the API rush multipliers, ft a story: 

Kushell, waking up from his hackerexp duties induced nap, sees a sponsor workshop is happening in 15 minutes. No one has reacted to the post on slack. *Shit*, he says, we need to pump this to the moon. He fires up the **ODSC CMS** (cuz we have one of those), which conveniently supports creating an Api Rush, just for moments like these. He creates a rush for sponsor tasks, with a 10x multiplier. He posts this in slack, and the crowd goes nuts. Everyone is showing up to the sponsor workshop to collect those sweet, sweet rewards. As volunteers scramble to check people in, every contribution getting added to our god log (the contributions table), is signed with a multiplier value, that gets calculated dynamically based on the multipliers table (trust, I got the SQL for this). After pulling off a miraculous save and wowing our sponsors with the incredible growth hacking we've built in, Kushell goes back to the **ODSC CMS**, and deletes the Api Rush, bringing things back to normal, and promptly goes back to taking his nap. 