### PR TITLE
[fix] fix bug with urlParams

### DIFF
--- a/lib/api-sdk/fetcher.tsx
+++ b/lib/api-sdk/fetcher.tsx
@@ -109,7 +109,7 @@ async function APIGet<T>(
   let urlRoute = computeUrlRoute(route, opts.req, param);
   if (opts.queryParams) {
     const urlParams = new URLSearchParams(Object.entries(opts.queryParams));
-    urlRoute += `?${urlParams};`;
+    urlRoute += `?${urlParams}`;
   }
 
   const headers = setupHeaders(opts.req, {});


### PR DESCRIPTION
the rogue semicolon messed up query params