### PR TITLE
[ci] add build job to circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,13 @@ jobs:
           command: "yarn run E2ETest"
       - store_artifacts:
           path: cypress/videos/odysseyTests
+  build:
+    docker:
+      - image: circleci/node
+    steps:
+      - checkout
+      - run: yarn install
+      - run: yarn build
   test:
     docker:
       - image: circleci/node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,34 +24,11 @@ jobs:
       - checkout
       - run: yarn install
       - run: yarn build
-  test:
-    docker:
-      - image: circleci/node
-    steps:
-      - checkout
-      - run: yarn install
-      - run: yarn run test
-  deploy:
-    docker:
-      - image: circleci/node
-    steps:
-      - checkout
-      - run: sudo npm install -g now
-      - run:
-          name: Deploy to Now
-          command: cd client && now --token $ZEIT_TOKEN --local-config now.production.json --prod
 workflows:
   version: 2
   e2e_tests:
     jobs:
-      - E2ETest
-  test_deploy:
+      - e2e_tests
+  build:
     jobs:
-      - E2ETest
-      - deploy:
-          requires:
-            - E2ETest
-          filters:
-            branches:
-              only:
-                - master
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
   version: 2
   e2e_tests:
     jobs:
-      - e2e_tests
+      - E2ETest
   build:
     jobs:
       - build


### PR DESCRIPTION
`yarn build` sometimes catches stuff we don't see in `yarn dev` 

this will run `yarn build` to ensure ci catches it so we don't accept a broken build PR 