### PR TITLE
[permissions] add volunteer role & admin role changer

### DIFF
--- a/api/admin.js
+++ b/api/admin.js
@@ -20,6 +20,43 @@ router.put("/:email", async (req, res) => {
   return res.json({ hackerProfile: newHackerProfile });
 });
 
+router.post("/profiles", async (req, res) => {
+  console.log('getting profiles')
+  try {
+    const profiles = await models.HackerProfile.findAll({
+      where: {
+        $or: [
+          {
+            email: {
+              $like: req.body
+            }
+          },
+          {
+            firstName: {
+              $like: req.body
+            }
+          },
+          {
+            lastName: {
+              $like: req.body
+            }
+          },
+        ]
+      },
+      include: [
+        {
+          model: models.HackerProfile
+        }
+      ]
+    });
+    return res.json({
+      profiles: profiles
+    });
+  } catch (e) {
+    return res.status(500).json({ error: e.message });
+  }
+});
+
 router.get("/reviews", async (req, res) => {
   try {
     const reviews = await models.HackerReview.findAll();

--- a/api/admin.js
+++ b/api/admin.js
@@ -22,6 +22,7 @@ router.put("/:email", async (req, res) => {
   return res.json({ hackerProfile: newHackerProfile });
 });
 
+// TODO: use the new client fetcher api
 router.get("/profiles", async (req, res) => {
   const Op = sequelize.Op
   const { query } = req.query;
@@ -67,7 +68,7 @@ router.post("/updateRole", async (req, res) => {
       }
     })
 
-    return res.json({ result: result })
+    return res.json({ success: result })
   } catch (e) {
     return res.status(500).json({ error: e.message});
   }

--- a/api/database/migrations/20200127000435-modify-role-superadmin-volunteer.js
+++ b/api/database/migrations/20200127000435-modify-role-superadmin-volunteer.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn("HackerProfiles", "role", {
+      type: Sequelize.ENUM,
+      values: ["hacker", "admin", "sponsor", "volunteer"],
+      defaultValue: "hacker"
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.changeColumn("HackerProfiles", "role", {
+      type: Sequelize.ENUM,
+      values: ["hacker", "admin", "sponsor", "superadmin"],
+      defaultValue: "hacker"
+    })
+  }
+};

--- a/api/models/hackerProfile.js
+++ b/api/models/hackerProfile.js
@@ -67,7 +67,7 @@ module.exports = (sequelize, DataTypes) => {
       questionThree: DataTypes.STRING(1000),
       role: {
         type: DataTypes.ENUM,
-        values: ["hacker", "admin", "sponsor", "superadmin"],
+        values: ["hacker", "admin", "sponsor", "volunteer"],
         defaultValue: "hacker"
       },
       graduationDate: {

--- a/lib/admin.tsx
+++ b/lib/admin.tsx
@@ -1,3 +1,27 @@
+export async function getHackerProfiles(searchText) {
+  const fetchUrl = process.env.URL_BASE
+  ? process.env.URL_BASE + "api/admin/profiles"
+  : "api/admin/profiles";
+
+  const response = await fetch(
+    fetchUrl,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(searchText)
+    }
+  );
+
+  const payload = await response.json();
+
+  // Randomly select an eligible review
+  const { profiles } = payload;
+
+  return profiles;
+}
+
 export async function getReviewHistory(req) {
   const fetchUrl = process.env.URL_BASE
     ? process.env.URL_BASE + "api/admin/reviewHistory"

--- a/lib/admin.tsx
+++ b/lib/admin.tsx
@@ -12,7 +12,6 @@ export async function getProfiles(query) {
 
   const payload = await response.json();
 
-  // Randomly select an eligible review
   const { profiles } = payload;
 
   return profiles;

--- a/lib/admin.tsx
+++ b/lib/admin.tsx
@@ -1,16 +1,12 @@
-export async function getHackerProfiles(searchText) {
+export async function getProfiles(query) {
   const fetchUrl = process.env.URL_BASE
-  ? process.env.URL_BASE + "api/admin/profiles"
-  : "api/admin/profiles";
+  ? process.env.URL_BASE + "api/admin/profiles?query=" + query 
+  : "api/admin/profiles?query=" + query;
 
   const response = await fetch(
     fetchUrl,
     {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify(searchText)
+      method: "GET"
     }
   );
 
@@ -20,6 +16,22 @@ export async function getHackerProfiles(searchText) {
   const { profiles } = payload;
 
   return profiles;
+}
+
+export async function updateProfileRole(email, role) {
+  const fetchUrl = process.env.URL_BASE
+  ? process.env.URL_BASE + "api/admin/updateRole" 
+  : "api/admin/updateRole"
+
+  const response = await fetch(fetchUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({email: email, role: role})
+  })
+
+  return response
 }
 
 export async function getReviewHistory(req) {

--- a/odyssey.d.ts
+++ b/odyssey.d.ts
@@ -42,7 +42,7 @@ declare type Profile = {
   questionOne: string;
   questionTwo: string;
   questionThree: string;
-  role: "hacker" | "admin" | "sponsor" | "superadmin";
+  role: "hacker" | "admin" | "sponsor" | "volunteer";
   graduationDate:
     | "spring-2020"
     | "fall-2020"

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -49,7 +49,7 @@ const Admin = ({ profile }) => {
               <ActionTitle>Check In Hackers</ActionTitle>
             </Action>     
             <Action href="/roleManager">
-              <ActionTitle> Manage roles </ActionTitle>
+              <ActionTitle> Manage Roles </ActionTitle>
             </Action>        
             <Action href="/taskManager">
               <ActionTitle> Manage Available Tasks </ActionTitle>

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -47,7 +47,10 @@ const Admin = ({ profile }) => {
             </Action>
             <Action href="/checkin">
               <ActionTitle>Check In Hackers</ActionTitle>
-            </Action>
+            </Action>     
+            <Action href="/roleManager">
+              <ActionTitle> Manage roles </ActionTitle>
+            </Action>        
             <Action href="/taskManager">
               <ActionTitle> Manage Available Tasks </ActionTitle>
             </Action>

--- a/pages/roleManager.tsx
+++ b/pages/roleManager.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from "react";
+
+import { handleLoginRedirect, getProfile } from "../lib/authenticate";
+
+import {
+  getHackerProfiles
+} from "../lib/admin";
+
+import Head from "../components/Head";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+import styled from "styled-components";
+
+import { Background, Container, Button, Flex, Column } from "../styles";
+
+const roleManager = ({ profile }) => {
+  const [searchText, setSearchText] = useState("")
+  const [searchResults, setSearchResults] = useState([])
+
+  const searchResultBlocks = searchResults.map(result => {
+    return (
+      <SearchResult>
+        {result}
+      </SearchResult>
+    )
+  })
+
+  const search = async function() {
+    const profiles = await getHackerProfiles(searchText)
+    console.log(profiles)
+    setSearchResults(profiles)
+  }
+
+  return (
+    <>
+      <Head title="HackSC Odyssey - Application" />
+      <Navbar loggedIn admin activePage="/" />
+      <Background>
+        <Container>
+          <SearchBar>
+            <Input
+              type="text"
+              onChange={e => {
+                setSearchText(e.target.value)
+              }}
+              placeholder="Search"
+              />
+            <Button
+              onClick={search}
+            >
+              Search
+            </Button>
+          </SearchBar>
+          {searchResultBlocks}      
+        </Container>
+      </Background>
+      <Footer />
+    </>
+  );
+};
+
+roleManager.getInitialProps = async ctx => {
+  const { req } = ctx;
+
+  const profile = await getProfile(req);
+
+  // Null profile means user is not logged in or user does not have enough rights
+  if (!profile || profile.role != "admin") {
+    handleLoginRedirect(req);
+  }
+
+  return { profile };
+};
+
+const SearchBar = styled(Flex)`
+  width: 100%;
+  margin-bottom: 10px;
+`;
+
+const SearchResult = styled.div`
+  padding: 10px 20px;
+  background: #ffffff;
+  border-radius: 8px;
+  font-size: 16px;
+  margin: 5px 0px;
+`;
+
+const Cell = styled.div`
+  display: inline-block;
+  padding: 10px 20px;
+  background: #ffffff;
+  border-radius: 8px;
+  font-size: 16px;
+`;
+
+const SmallCell = styled.div`
+  padding: 12px 1px;
+  background: #ffffff;
+  border-radius: 8px;
+  border: 1px solid #b2b2b2;
+  min-width: 39px;
+  display: inline-block;
+  text-align: center;
+  font-size: 16px;
+`;
+
+const Panel = styled.div`
+  padding: 24px 36px;
+  margin: 0 0 16px;
+  background: #ffffff;
+  border-radius: 4px;
+`;
+
+const Input = styled.input`
+  border-radius: 8px;
+  border: 1px solid #b2b2b2;
+  padding: 12px 16px;
+  font-weight: 300;
+  color: ${({ theme }) => theme.colors.black};
+  font-size: 16px;
+  width: 100%;
+  box-sizing: border-box;
+`;
+
+const InvisInput = styled.input`
+  display: none;
+`;
+
+const TableInput = styled.input`
+  display: inline-block;
+  width: 25px;
+  padding: 12px 8px;
+  margin-right: 1px;
+  border-radius: 8px;
+  border: 1px solid ${({ theme }) => theme.colors.gray5};
+  color: ${({ theme }) => theme.colors.gray50};
+`;
+
+const FullButton = styled(Button)`
+  width: 100%;
+  text-align: center;
+`;
+
+const FullStyledButton = styled(Button)`
+  width: 100%;
+  text-align: center;
+  ${({ disabled }) => disabled && `opacity: 0.5`};
+`;
+
+const StyledButton = styled(Button)`
+  ${({ disabled }) => disabled && `opacity: 0.5`};
+`;
+
+export default roleManager;


### PR DESCRIPTION
Really simple addition for role-setting capabilities when you're an admin

Someone double check my migration to make sure its good, since I've never done it before. Basically I updated the enums for hackerprofile roles from ['hacker', 'admin', 'sponsor', 'superadmin'] to ['hacker', 'admin', 'sponsor', 'volunteer']. I don't think this changes anything on prod since nobody is superadmin.

This is what it looks like:
![image](https://user-images.githubusercontent.com/12589980/73500086-b039c780-4376-11ea-9bb7-f1f0db8f6f3c.png)
