### PR TITLE
[server] [feature] Adds serverside support for calculating user Points 

### DIFF
--- a/api/live.js
+++ b/api/live.js
@@ -329,4 +329,24 @@ router.get("/identity-check/:userId", async (req, res) => {
   }
 });
 
+router.get("/hacker/:qrCodeId", async (req, res) => {
+  const qrCodeId = req.params.qrCodeId;
+  const result = await models.HackerProfile.findOne({
+    where: {
+      qrCodeId: qrCodeId
+    }
+  });
+  const userId = result.get("userId");
+  const contributions = await models.Contribution.findAll({
+    where: {
+      personId: userId
+    },
+    attributes: [
+      [sequelize.fn("SUM", sequelize.col("Task.points")), "totalPoints"]
+    ],
+    include: [{ model: models.Task, required: true }]
+  });
+  return res.json({ success: contributions });
+});
+
 module.exports = router;

--- a/api/live.js
+++ b/api/live.js
@@ -336,6 +336,9 @@ router.get("/hacker/:qrCodeId", async (req, res) => {
       qrCodeId: qrCodeId
     }
   });
+  if (!result) {
+    return res.status(404).json({ error: "Hacker not Found" });
+  }
   const userId = result.get("userId");
   const contributions = await models.Contribution.findAll({
     where: {


### PR DESCRIPTION
## What 

* Adds endpoint that returns the following Shape: 
```json
{"success":[
{"totalPoints":"26",
"Task": {"id":11,
"points":13,
"description":"",
"blocking":false,
"type":"volunteer",
"isGroupTask":null,
"isActive":true,
"name":"TestTask1",
"createdAt":"2020-01-26T20:31:04.000Z",
"updatedAt":"2020-01-29T03:19:32.000Z",
"groupingId":1}}]}
```

Thought is to hook up the scanner to return this, and return the "totalPoints" value to the volunteer, so we can determine hacker's total points quickly for project dist.