### PR TITLE
fix missing application page

### DIFF
--- a/components/steps/Status.tsx
+++ b/components/steps/Status.tsx
@@ -151,7 +151,7 @@ const StatusStep: React.FunctionComponent<Props> = props => {
               </p>
 
               {getStage(profile) === 2 && (
-                <StepButton onClick={() => navigateTo("application")}>
+                <StepButton onClick={() => navigateTo("appform")}>
                   Fill out application
                 </StepButton>
               )}

--- a/pages/appform.tsx
+++ b/pages/appform.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import { handleLoginRedirect, getProfile } from "../lib/authenticate";
+import { getReferrerCode } from "../lib/referrerCode";
+
+import Head from "../components/Head";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+
+import { Background, Container } from "../styles";
+
+import Step from "../components/steps/Profile";
+
+const appform = ({ profile }) => {
+  return (
+    <>
+      <Head title="HackSC Odyssey - Application" />
+      <Navbar
+        showProjectTeam={profile ? profile.status === "checkedIn" : false}
+        loggedIn
+        activePage="application"
+      />
+      <Background>
+        <Container>{profile && <Step profile={profile} />}</Container>
+      </Background>
+      <Footer />
+    </>
+  );
+};
+
+appform.getInitialProps = async ctx => {
+  const { req } = ctx;
+
+  const profile = await getProfile(req);
+
+  // Null profile means user is not logged in
+  if (!profile) {
+    handleLoginRedirect(req);
+  }
+
+  //Referrer Code Special Case Handling
+  profile.referrerCode = getReferrerCode(ctx, profile);
+
+  return {
+    profile
+  };
+};
+
+export default appform;

--- a/pages/appform.tsx
+++ b/pages/appform.tsx
@@ -36,10 +36,10 @@ appform.getInitialProps = async ctx => {
   // Null profile means user is not logged in
   if (!profile) {
     handleLoginRedirect(req);
+  } else {
+    //Referrer Code Special Case Handling
+    profile.referrerCode = getReferrerCode(ctx, profile);
   }
-
-  //Referrer Code Special Case Handling
-  profile.referrerCode = getReferrerCode(ctx, profile);
 
   return {
     profile


### PR DESCRIPTION
Closes #361 

when clicking `fill out my application` on application page, it re-routed to the same page. The previous page was removed when the live website was merged.