### PR TITLE
fixed event routes + edited events widget

### DIFF
--- a/api/event.js
+++ b/api/event.js
@@ -12,7 +12,12 @@ router.use(utils.requireAdmin);
 
 router.get("/", async (req, res) => {
   try {
-    const events = await models.Event.findAll();
+    const events = await models.Event.findAll({
+      order: [
+        ['startsAt', 'ASC'],
+        ['endsAt', 'ASC']
+      ]
+    });
     return res.json({ events });
   } catch (e) {
     return res.json({ err: e });

--- a/api/public.js
+++ b/api/public.js
@@ -5,7 +5,12 @@ const router = express.Router();
 
 router.get("/events/list", cors(), async (req, res) => {
   try {
-    const events = await models.Event.findAll();
+    const events = await models.Event.findAll({
+      order: [
+        ['startsAt', 'ASC'],
+        ['endsAt', 'ASC']
+      ]
+    });
     return res.json({ events });
   } catch (e) {
     return res.json({ err: e });

--- a/components/hackerDashboard/widgets/sidebar/events.tsx
+++ b/components/hackerDashboard/widgets/sidebar/events.tsx
@@ -1,25 +1,38 @@
 import styled from "styled-components";
+import moment from "moment-timezone";
+import { useEffect } from "react";
 
 const HackathonEvents = ({ events }) => {
+  const currentDate = moment.tz(moment(), 'Pacific');
+  let nextEvent;
+  for (let i = 0; i < events.length; i++) {
+    nextEvent = events[i].id;
+    if (moment(events[i].startsAt) > currentDate) {
+      break;
+    }
+  }
+
+  useEffect(() => {
+    document.getElementById("eventList").scrollTop = document.getElementById(nextEvent).offsetTop;
+  }, []);
+
   return (
     <div>
       <h3>Upcoming Events</h3>
       <h4>All in Pacific Standard Time</h4>
-      <EventList>
-        {events.map((e) => (
-          <Event>
-            <h3>{e.name}</h3>
+      <EventList id="eventList">
+        {events.map((e) => 
+          <Event id={e.id} style={ moment(e.endsAt) > currentDate ? { color:"#FFFFFF" } : { color:"#7E7E7E" }}>
+            <h3 style={ moment(e.endsAt) > currentDate ? { color:"#FF8379" } : { color:"#7E7E7E" }}>{e.name}</h3>
             <p>{e.description}</p>
             <p>
-              {new Date(e.startsAt).toLocaleTimeString()}{" "}
-              {new Date(e.startsAt).toLocaleDateString()}
+              {moment(e.startsAt).format('MMM D, h:mm a')}
             </p>
             <p>
-              {new Date(e.endsAt).toLocaleTimeString()}{" "}
-              {new Date(e.endsAt).toLocaleDateString()}
+              {moment(e.endsAt).format('MMM D, h:mm a')}
             </p>
           </Event>
-        ))}
+        )}
       </EventList>
     </div>
   );
@@ -30,6 +43,7 @@ const EventList = styled.div`
   margin-top: 8px;
   max-height: 400px;
   overflow: scroll;
+  position: relative;
 `;
 
 const Event = styled.div`

--- a/components/hackerDashboard/widgets/sidebar/events.tsx
+++ b/components/hackerDashboard/widgets/sidebar/events.tsx
@@ -7,7 +7,7 @@ const HackathonEvents = ({ events }) => {
   let nextEvent;
   for (let i = 0; i < events.length; i++) {
     nextEvent = events[i].id;
-    if (moment(events[i].startsAt) > currentDate) {
+    if (moment(events[i].endsAt) > currentDate || moment(events[i].startsAt) > currentDate) {
       break;
     }
   }


### PR DESCRIPTION
Changed public and admin get event routes to sort by ascending

Events widget: updated dates, scroll position starts at next event, old events are grayed out


![image](https://user-images.githubusercontent.com/19981533/106428891-81897d80-641e-11eb-8c30-f39461cdf2a3.png)
(screenshot is pre-date-formatting, but example of where the scrollbar would be on page load)

![image](https://user-images.githubusercontent.com/19981533/106428949-98c86b00-641e-11eb-8ee2-83a1536713c3.png)
(grayed-out events)